### PR TITLE
Fix imports requiring dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@t3ned/channel",
-	"version": "1.0.0-alpha",
+	"version": "1.0.6-alpha",
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",
 	"author": "T3NED <oss@t3ned.dev>",
@@ -18,7 +18,9 @@
 	},
 	"files": [
 		"dist",
-		"!dist/*.tsbuildinfo"
+		"!dist/*.tsbuildinfo",
+		"*.js",
+		"*.d.ts"
 	],
 	"keywords": [
 		"ergonomic",
@@ -35,7 +37,9 @@
 		"watch:build": "npx tsc -w",
 		"lint": "npx eslint src --fix",
 		"test": "npx vitest run --coverage",
-		"watch:test": "npx vitest --coverage"
+		"watch:test": "npx vitest --coverage",
+		"prepublish": "node scripts/pre-publish.js",
+		"postpublish": "node scripts/post-publish.js"
 	},
 	"optionalDependencies": {
 		"@types/express": "^4.17.13",

--- a/scripts/post-publish.js
+++ b/scripts/post-publish.js
@@ -1,0 +1,15 @@
+const { readdirSync, rmSync } = require("fs");
+const { join } = require("path");
+
+const supportedModulesPath = join(process.cwd(), "src", "modules");
+const supportedModuleNames = readdirSync(supportedModulesPath, "utf-8");
+
+const deleteFileInRoot = (name) => {
+	rmSync(join(process.cwd(), name));
+	console.log(`DELETE ${name}`);
+};
+
+for (const supportedModuleName of supportedModuleNames) {
+	deleteFileInRoot(`${supportedModuleName}.js`);
+	deleteFileInRoot(`${supportedModuleName}.d.ts`);
+}

--- a/scripts/pre-publish.js
+++ b/scripts/pre-publish.js
@@ -1,0 +1,18 @@
+const { readdirSync, writeFileSync } = require("fs");
+const { join } = require("path");
+
+const supportedModulesPath = join(process.cwd(), "src", "modules");
+const supportedModuleNames = readdirSync(supportedModulesPath, "utf-8");
+
+const createFileInRoot = (name, content) => {
+	writeFileSync(join(process.cwd(), name), content, "utf-8");
+	console.log(`CREATE ${name}`);
+};
+
+for (const supportedModuleName of supportedModuleNames) {
+	const js = `module.exports = require("./dist/${supportedModuleName}");\n`;
+	const ts = `export * from "./dist/${supportedModuleName}";\n`;
+
+	createFileInRoot(`${supportedModuleName}.js`, js);
+	createFileInRoot(`${supportedModuleName}.d.ts`, ts);
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,4 @@
 {
 	"extends": "./tsconfig.json",
-	"include": ["src", "tests"]
+	"include": ["src", "tests", "scripts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,8 +24,8 @@
 		"checkJs": true,
 
 		/* Emit */
-		"declaration": false,
-		"declarationMap": false,
+		"declaration": true,
+		"declarationMap": true,
 		"sourceMap": true,
 		"removeComments": true,
 		"importsNotUsedAsValues": "error",


### PR DESCRIPTION
**Problem**
Importing the package modules (`express` or `fastify`) requires `/dist` in the package name to access the module:

`import { Application } from "channel/dist/express";`

**Solution**
Export a file for each of the modules to remove the `/dist` prefix
`import { Application } from "channel/express";`